### PR TITLE
Use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
       [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
     default: ${{ github.token }}
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: umbrella


### PR DESCRIPTION
This should help with fixing the following deprecation warning @ghys:

![Screenshot from 2022-12-11 14-24-35](https://user-images.githubusercontent.com/12213581/206906667-56391920-8fec-4d8d-943f-83f36d4b0167.png)

See also: https://github.com/openhab/openhab-webui/actions/runs/3668718598

I'm planning to create PRs with upgraded GHA workflow actions to fix all the other deprecation warnings as well.

I gave this change as well as the other upgrades a brief test, see:

https://github.com/wborn/openhab-addons/pull/8
https://github.com/wborn/openhab-addons/actions/runs/3669154817