### PR TITLE
Use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
       [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
     default: ${{ github.token }}
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: umbrella


### PR DESCRIPTION
This fixes the following deprecation warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: ghys/checkstyle-github-action@main. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.